### PR TITLE
Small fixes and improvements of installation scripts

### DIFF
--- a/config
+++ b/config
@@ -437,10 +437,10 @@ exec --no-startup-id nm-applet
 exec_always --no-startup-id numlockx on
 
 # dropbox
-# exec --no-startup-id dropbox start
+exec --no-startup-id dropbox start
 
 # insync
-# exec --no-startup-id insync start
+exec --no-startup-id insync start
 
 # volume
 #exec --no-startup-id pasystray

--- a/config
+++ b/config
@@ -437,10 +437,10 @@ exec --no-startup-id nm-applet
 exec_always --no-startup-id numlockx on
 
 # dropbox
-exec --no-startup-id dropbox start
+# exec --no-startup-id dropbox start
 
 # insync
-exec --no-startup-id insync start
+# exec --no-startup-id insync start
 
 # volume
 #exec --no-startup-id pasystray

--- a/installation/110-install-xcb-util-xrm-v1.sh
+++ b/installation/110-install-xcb-util-xrm-v1.sh
@@ -11,6 +11,11 @@ echo "###############################"
 echo "Xcb-util-xrm"
 echo "###############################"
 
+if [ -f "/usr/include/xcb/xcb_xrm.h" ]; then
+    echo "It seems \"Xcb-util-xrm\" is installed already. Skipping reinstallation."
+    exit
+fi
+
 # dependancy on xcb-util-xrm
 
 rm -rf /tmp/xcb-util-xrm

--- a/installation/110-install-xcb-util-xrm-v1.sh
+++ b/installation/110-install-xcb-util-xrm-v1.sh
@@ -17,7 +17,7 @@ rm -rf /tmp/xcb-util-xrm
 git clone --recursive https://github.com/Airblader/xcb-util-xrm.git /tmp/xcb-util-xrm
 cd /tmp/xcb-util-xrm
 git submodule update --init
-sh /tmp/xcb-util-xrm/autogen.sh --prefix=/usr
+bash /tmp/xcb-util-xrm/autogen.sh --prefix=/usr
 make && sudo make install
 
 rm -rf /tmp/xcb-util-xrm

--- a/installation/410-install-icons-v1.sh
+++ b/installation/410-install-icons-v1.sh
@@ -7,13 +7,13 @@ set -e
 #
 ##################################################################################################################
 
-sh icons/icons-sardi-extra-v4.sh
+bash icons/icons-sardi-extra-v4.sh
 
 
-sh icons/icons-sardi-v3.sh
+bash icons/icons-sardi-v3.sh
 
 
-sh icons/icons-surfn-v4.sh
+bash icons/icons-surfn-v4.sh
 
 
 

--- a/installation/420-install-themes-v1.sh
+++ b/installation/420-install-themes-v1.sh
@@ -7,9 +7,9 @@ set -e
 #
 ##################################################################################################################
 
-sh themes/theme-arc-colora-collection-3.4-v1.sh
-sh themes/theme-mint-y-colora-collection-3.4-v1.sh
-sh themes/install-gtk-arc-theme-v1.sh
+bash themes/theme-arc-colora-collection-3.4-v1.sh
+bash themes/theme-mint-y-colora-collection-3.4-v1.sh
+bash themes/install-gtk-arc-theme-v1.sh
 
 
 

--- a/installation/420-install-themes-v1.sh
+++ b/installation/420-install-themes-v1.sh
@@ -9,7 +9,7 @@ set -e
 
 bash themes/theme-arc-colora-collection-3.4-v1.sh
 bash themes/theme-mint-y-colora-collection-3.4-v1.sh
-bash themes/install-gtk-arc-theme-v1.sh
+# bash themes/install-gtk-arc-theme-v1.sh
 
 
 

--- a/installation/430-install-applications-v1.sh
+++ b/installation/430-install-applications-v1.sh
@@ -7,23 +7,23 @@ set -e
 #
 ##################################################################################################################
 
-sh applications/install-sublime-text-v1.sh
+bash applications/install-sublime-text-v1.sh
 
-sh applications/install-spotify-v2.sh
+bash applications/install-spotify-v2.sh
 
-sh applications/install-variety-v1.sh
+bash applications/install-variety-v1.sh
 
-sh applications/install-atom-v1.sh
+bash applications/install-atom-v1.sh
 
-sh applications/install-google-chrome-v1.sh
+bash applications/install-google-chrome-v1.sh
 
-sh applications/install-neofetch-v1.sh
+bash applications/install-neofetch-v1.sh
 
-sh applications/install-simplescreenrecorder-v1.sh
+bash applications/install-simplescreenrecorder-v1.sh
 
-sh applications/install-vivaldi-snapshot-v1.sh
+bash applications/install-vivaldi-snapshot-v1.sh
 
-sh applications/install-zsh-v1.sh
+bash applications/install-zsh-v1.sh
 
 
 

--- a/installation/600-copy-personal-settings.sh
+++ b/installation/600-copy-personal-settings.sh
@@ -44,7 +44,7 @@ cp settings/settings.ini ~/.config/gtk-3.0/
 
 #echo "Making sure gnome-screenshot saves in jpg - smaller in kb"
 
-#sh settings/gnome-screenshot/set-gnome-screenshot-to-save-as-jpg.sh
+#bash settings/gnome-screenshot/set-gnome-screenshot-to-save-as-jpg.sh
 
 echo "Copy/pasting gimp scripts and themes"
 

--- a/installation/600-copy-personal-settings.sh
+++ b/installation/600-copy-personal-settings.sh
@@ -42,9 +42,9 @@ cp settings/.gtkrc-2.0 ~/
 #cp settings/bookmarks ~/.config/gtk-3.0/
 cp settings/settings.ini ~/.config/gtk-3.0/
 
-#echo "Making sure gnome-screenshot saves in jpg - smaller in kb"
+echo "Making sure gnome-screenshot saves in jpg - smaller in kb"
 
-#bash settings/gnome-screenshot/set-gnome-screenshot-to-save-as-jpg.sh
+bash settings/gnome-screenshot/set-gnome-screenshot-to-save-as-jpg.sh
 
 echo "Copy/pasting gimp scripts and themes"
 

--- a/installation/600-copy-personal-settings.sh
+++ b/installation/600-copy-personal-settings.sh
@@ -42,9 +42,9 @@ cp settings/.gtkrc-2.0 ~/
 #cp settings/bookmarks ~/.config/gtk-3.0/
 cp settings/settings.ini ~/.config/gtk-3.0/
 
-echo "Making sure gnome-screenshot saves in jpg - smaller in kb"
+#echo "Making sure gnome-screenshot saves in jpg - smaller in kb"
 
-sh settings/gnome-screenshot/set-gnome-screenshot-to-save-as-jpg.sh
+#sh settings/gnome-screenshot/set-gnome-screenshot-to-save-as-jpg.sh
 
 echo "Copy/pasting gimp scripts and themes"
 

--- a/installation/900-copy-i3-files-to-config-i3-folder-v2.sh
+++ b/installation/900-copy-i3-files-to-config-i3-folder-v2.sh
@@ -162,7 +162,7 @@ echo "################################################################"
 echo "Downloading the files from github to /tmp directory " $GITHUB
 
 
-git clone https://github.com/erikdubois/$GITHUB /tmp/$GITHUB
+git clone https://github.com/proger4ever/$GITHUB /tmp/$GITHUB
 
 
 echo "################################################################"

--- a/installation/900-copy-i3-files-to-config-i3-folder-v2.sh
+++ b/installation/900-copy-i3-files-to-config-i3-folder-v2.sh
@@ -162,7 +162,7 @@ echo "################################################################"
 echo "Downloading the files from github to /tmp directory " $GITHUB
 
 
-git clone https://github.com/proger4ever/$GITHUB /tmp/$GITHUB
+git clone https://github.com/erikdubois/$GITHUB /tmp/$GITHUB
 
 
 echo "################################################################"

--- a/installation/applications/install-atom-v1.sh
+++ b/installation/applications/install-atom-v1.sh
@@ -13,16 +13,24 @@
 
 # will not install to error....????
 
+REPO_PACKAGE="atom"
+FILE_PACKAGE="atom-amd64.deb"
 
-rm /tmp/atom-amd64.deb
 
-wget https://atom.io/download/deb -O /tmp/atom-amd64.deb
+if [[ ! -z `dpkg --get-selections $REPO_PACKAGE | grep install` ]]; then
+    echo "package \"$REPO_PACKAGE\" already installed.";
+    exit;
+fi
+
+rm /tmp/$FILE_PACKAGE
+
+wget https://atom.io/download/deb -O /tmp/$FILE_PACKAGE
 #curl -o /tmp/code_1.5.3-1474533365_amd64.deb https://code.visualstudio.com/docs/?dv=linux64_deb
-sudo dpkg -i /tmp/atom-amd64.deb
+sudo dpkg -i /tmp/$FILE_PACKAGE
 #gdebi /tmp/code_1.5.3-1474533365_amd64.deb
 
 
-rm /tmp/atom-amd64.deb
+rm /tmp/$FILE_PACKAGE
 
 
 ##################################################################################################################

--- a/installation/applications/install-google-chrome-v1.sh
+++ b/installation/applications/install-google-chrome-v1.sh
@@ -14,13 +14,22 @@
 
 # donwloading and installing google chrome for netflix e.g.
 
-rm /tmp/google-chrome-stable_current_amd64.deb
+$REPO_PACKAGE="google-chrome-stable"
+$FILE_PACKAGE="$FILE_PACKAGE"
+
+
+if [[ ! -z `dpkg --get-selections $REPO_PACKAGE | grep install` ]]; then
+    echo "$REPO_PACKAGE already installed.";
+    exit;
+fi
+
+rm /tmp/$FILE_PACKAGE
 
 echo "downloading google chrome latest stable edition"
-wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -O /tmp/google-chrome-stable_current_amd64.deb
-sudo dpkg -i /tmp/google-chrome-stable_current_amd64.deb
+wget https://dl.google.com/linux/direct/$FILE_PACKAGE -O /tmp/$FILE_PACKAGE
+sudo dpkg -i /tmp/$FILE_PACKAGE
 
-rm /tmp/google-chrome-stable_current_amd64.deb
+rm /tmp/$FILE_PACKAGE
 
 echo "################################################################"
 echo "###################    google chrome installed #################"

--- a/installation/applications/install-google-chrome-v1.sh
+++ b/installation/applications/install-google-chrome-v1.sh
@@ -14,12 +14,12 @@
 
 # donwloading and installing google chrome for netflix e.g.
 
-$REPO_PACKAGE="google-chrome-stable"
-$FILE_PACKAGE="$FILE_PACKAGE"
+REPO_PACKAGE="google-chrome-stable"
+FILE_PACKAGE="google-chrome-stable_current_amd64.deb"
 
 
 if [[ ! -z `dpkg --get-selections $REPO_PACKAGE | grep install` ]]; then
-    echo "$REPO_PACKAGE already installed.";
+    echo "package \"$REPO_PACKAGE\" already installed.";
     exit;
 fi
 

--- a/installation/applications/install-neofetch-v1.sh
+++ b/installation/applications/install-neofetch-v1.sh
@@ -15,10 +15,12 @@
 
 # repo for spotify
 
-sudo add-apt-repository -y ppa:dawidd0811/neofetch
+THE_PPA="dawidd0811/neofetch"
 
-# getting new info of this new repo
-sudo apt-get -y update
+if [[ -z `grep -R "$THE_PPA" /etc/apt/` ]]; then
+    sudo add-apt-repository -y ppa:$THE_PPA
+    sudo apt-get update
+fi
 
 # installing
 sudo apt install neofetch -y

--- a/installation/applications/install-screenkey-v1.sh
+++ b/installation/applications/install-screenkey-v1.sh
@@ -11,11 +11,19 @@
 #
 ##################################################################################################################
 
+OPT_NAME="screenkey"
+INSTALL_DIR="/opt/screenkey"
 
-sudo rm -rf /opt/screenkey
+
+if [ -d "$INSTALL_DIR" ]; then
+    echo "It seems, that \"$OPT_NAME\" already installed. Skipping reinstallation.";
+    exit;
+fi
+
+sudo rm -rf $INSTALL_DIR
 sudo apt-get install python-gtk2 python-setuptools python-setuptools-git python-distutils-extra -y
-sudo git clone https://github.com/wavexx/screenkey.git /opt/screenkey
-cd /opt/screenkey
+sudo git clone https://github.com/wavexx/screenkey.git $INSTALL_DIR
+cd $INSTALL_DIR
 sudo ./setup.py install
 
 echo "################################################################"

--- a/installation/applications/install-simplescreenrecorder-v1.sh
+++ b/installation/applications/install-simplescreenrecorder-v1.sh
@@ -11,9 +11,13 @@
 #
 ##################################################################################################################
 
+THE_PPA="maarten-baert/simplescreenrecorder"
 
-sudo add-apt-repository -y ppa:maarten-baert/simplescreenrecorder
-sudo apt-get update
+if [[ -z `grep -R "$THE_PPA" /etc/apt/` ]]; then
+    sudo add-apt-repository -y ppa:$THE_PPA
+    sudo apt-get update
+fi
+
 sudo apt-get install -y simplescreenrecorder
 
 echo "################################################################"

--- a/installation/applications/install-spotify-v2.sh
+++ b/installation/applications/install-spotify-v2.sh
@@ -11,7 +11,12 @@
 #
 ##################################################################################################################
 
+REPO_PACKAGE="spotify-client"
 
+if [[ ! -z `dpkg --get-selections $REPO_PACKAGE | grep install` ]]; then
+    echo "package \"$REPO_PACKAGE\" already installed.";
+    exit;
+fi
 
 # 1. Add the Spotify repository signing key to be able to verify downloaded packages
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys BBEBDCB318AD50EC6865090613B00F1FD2C19886

--- a/installation/applications/install-sublime-text-v1.sh
+++ b/installation/applications/install-sublime-text-v1.sh
@@ -11,12 +11,21 @@
 #
 ##################################################################################################################
 
-rm /tmp/sublime-text_build-3126_amd64.deb
+REPO_PACKAGE="sublime-text"
+FILE_PACKAGE="sublime-text_build-3126_amd64.deb"
 
-wget https://download.sublimetext.com/sublime-text_build-3126_amd64.deb -O /tmp/sublime-text_build-3126_amd64.deb
-sudo dpkg -i /tmp/sublime-text_build-3126_amd64.deb
 
-rm /tmp/sublime-text_build-3126_amd64.deb
+if [[ ! -z `dpkg --get-selections $REPO_PACKAGE | grep install` ]]; then
+    echo "package \"$REPO_PACKAGE\" already installed.";
+    exit;
+fi
+
+rm /tmp/$FILE_PACKAGE
+
+wget https://download.sublimetext.com/$FILE_PACKAGE -O /tmp/$FILE_PACKAGE
+sudo dpkg -i /tmp/$FILE_PACKAGE
+
+rm /tmp/$FILE_PACKAGE
 
 
 ##################################################################################################################

--- a/installation/applications/install-variety-v1.sh
+++ b/installation/applications/install-variety-v1.sh
@@ -13,8 +13,14 @@
 
 
 # Downloading and installing latest variety
-sudo add-apt-repository ppa:peterlevi/ppa -y
-sudo apt-get update
+
+THE_PPA="peterlevi/ppa"
+
+if [[ -z `grep -R "$THE_PPA" /etc/apt/` ]]; then
+    sudo add-apt-repository -y ppa:$THE_PPA
+    sudo apt-get update
+fi
+
 sudo apt-get install variety -y
 
 

--- a/installation/applications/install-vivaldi-snapshot-v1.sh
+++ b/installation/applications/install-vivaldi-snapshot-v1.sh
@@ -12,11 +12,14 @@
 ##################################################################################################################
 
 
+REPO="deb http://repo.vivaldi.com/archive/deb/ stable main"
 
+if [[ -z `grep -R "$REPO" /etc/apt/` ]]; then
+    sudo add-apt-repository "$REPO"
+    wget -qO- http://repo.vivaldi.com/archive/linux_signing_key.pub | sudo apt-key add -
+    sudo apt update
+fi
 
-sudo add-apt-repository 'deb http://repo.vivaldi.com/archive/deb/ stable main'
-wget -qO- http://repo.vivaldi.com/archive/linux_signing_key.pub | sudo apt-key add -
-sudo apt update
 sudo apt install vivaldi-snapshot
 
 

--- a/installation/automatic-installation-v1.sh
+++ b/installation/automatic-installation-v1.sh
@@ -13,24 +13,24 @@
 
 echo "Let us install i3"
 
-sh 100-install-dependencies-v1.sh
-sh 110-install-xcb-util-xrm-v1.sh
-sh 120-install-i3-gaps-next-v1.sh
+bash 100-install-dependencies-v1.sh
+bash 110-install-xcb-util-xrm-v1.sh
+bash 120-install-i3-gaps-next-v1.sh
 
-sh 300-install-extra-software-v1.sh
+bash 300-install-extra-software-v1.sh
 
-sh 400-install-fonts-v1.sh
+bash 400-install-fonts-v1.sh
 
-sh 410-install-icons-v1.sh
+bash 410-install-icons-v1.sh
 
-sh 420-install-themes-v1.sh
+bash 420-install-themes-v1.sh
 
-sh 430-install-applications-v1.sh
+bash 430-install-applications-v1.sh
 
-sh 600-copy-personal-settings.sh
+bash 600-copy-personal-settings.sh
 
 
-sh 900-copy-i3-files-to-config-i3-folder-v2.sh
+bash 900-copy-i3-files-to-config-i3-folder-v2.sh
 
 echo "###################################################"
 echo "##############     Auto script terminated     #################"

--- a/installation/aux-commands.sh
+++ b/installation/aux-commands.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo chsh $USER -s /bin/zsh

--- a/installation/icons/icons-sardi-extra-v4.sh
+++ b/installation/icons/icons-sardi-extra-v4.sh
@@ -11,12 +11,20 @@ set -e
 #
 ##################################################################################################################
 
+ICON_PACKAGE="Sardi-Extra"
+ICON_FOLDER_TO_CHECK="Sardi-Colora-Aquamarine"
 
 # cleaning tmp
-[ -d /tmp/Sardi-Extra ] && rm -rf /tmp/Sardi-Extra
+[ -d /tmp/$ICON_PACKAGE ] && rm -rf /tmp/$ICON_PACKAGE
 
 # if there is no hidden folder then make one
 [ -d $HOME"/.icons" ] || mkdir -p $HOME"/.icons"
+
+
+if [ -d $HOME"/.icons/$ICON_FOLDER_TO_CHECK" ]; then
+    echo "It seems \"$ICON_PACKAGE\" is installed already. Skipping reinstallation."
+    exit
+fi
 
 
 ##################################################################################################################
@@ -137,13 +145,13 @@ case $DISTRO in
 esac
 
 
-git clone https://github.com/erikdubois/Sardi-Extra /tmp/Sardi-Extra
-find /tmp/Sardi-Extra -maxdepth 1 -type f -exec rm -rf '{}' \;
+git clone https://github.com/erikdubois/$ICON_PACKAGE /tmp/$ICON_PACKAGE
+find /tmp/$ICON_PACKAGE -maxdepth 1 -type f -exec rm -rf '{}' \;
 
-cp -rf /tmp/Sardi-Extra/* ~/.icons/
+cp -rf /tmp/$ICON_PACKAGE/* ~/.icons/
 
 # cleaning tmp
-[ -d /tmp/Sardi-Extra ] && rm -rf /tmp/Sardi-Extra
+[ -d /tmp/$ICON_PACKAGE ] && rm -rf /tmp/$ICON_PACKAGE
 
 
 

--- a/installation/icons/icons-sardi-v3.sh
+++ b/installation/icons/icons-sardi-v3.sh
@@ -11,24 +11,31 @@
 #
 ##################################################################################################################
 
+ICON_PACKAGE="sardi"
+ICON_FOLDER_TO_CHECK="Sardi"
 
 # cleaning tmp
-[ -d /tmp/sardi ] && rm -rf /tmp/sardi
+[ -d /tmp/$ICON_PACKAGE ] && rm -rf /tmp/$ICON_PACKAGE
 
 # if there is no hidden folder then make one
 [ -d $HOME"/.icons" ] || mkdir -p $HOME"/.icons"
 
-wget -O /tmp/sardi.tar.gz "https://sourceforge.net/projects/sardi/files/latest/download?source=files"
-mkdir /tmp/sardi
-tar -zxf /tmp/sardi.tar.gz -C /tmp/sardi
-rm /tmp/sardi.tar.gz
-cp -rf /tmp/sardi/* ~/.icons/
+if [ -d $HOME"/.icons/$ICON_FOLDER_TO_CHECK" ]; then
+    echo "It seems \"$ICON_PACKAGE\" is installed already. Skipping reinstallation."
+    exit
+fi
+
+wget -O /tmp/$ICON_PACKAGE.tar.gz "https://sourceforge.net/projects/sardi/files/latest/download?source=files"
+mkdir /tmp/$ICON_PACKAGE
+tar -zxf /tmp/$ICON_PACKAGE.tar.gz -C /tmp/$ICON_PACKAGE
+rm /tmp/$ICON_PACKAGE.tar.gz
+cp -rf /tmp/$ICON_PACKAGE/* ~/.icons/
 
 # cleaning tmp
-[ -d /tmp/sardi ] && rm -rf /tmp/sardi
+[ -d /tmp/$ICON_PACKAGE ] && rm -rf /tmp/$ICON_PACKAGE
 
 
 
 echo "################################################################"
-echo "###################    icons sardi done   ######################"
+echo "###################    icons $ICON_PACKAGE done   ######################"
 echo "################################################################"

--- a/installation/icons/icons-surfn-v4.sh
+++ b/installation/icons/icons-surfn-v4.sh
@@ -11,11 +11,19 @@
 #
 ##################################################################################################################
 
+ICON_PACKAGE="Surfn"
+ICON_FOLDER_TO_CHECK="Surfn"
+
 # cleaning tmp
-[ -d /tmp/Surfn ] && rm -rf /tmp/Surfn
+[ -d /tmp/$ICON_PACKAGE ] && rm -rf /tmp/$ICON_PACKAGE
 
 # if there is no hidden folder then make one
 [ -d $HOME"/.icons" ] || mkdir -p $HOME"/.icons"
+
+if [ -d $HOME"/.icons/$ICON_FOLDER_TO_CHECK" ]; then
+    echo "It seems \"$ICON_PACKAGE\" is installed already. Skipping reinstallation."
+    exit
+fi
 
 
 ##################################################################################################################
@@ -135,12 +143,12 @@ case $DISTRO in
 		;;
 esac
 
-git clone https://github.com/erikdubois/Surfn /tmp/Surfn
-find /tmp/Surfn -maxdepth 1 -type f -exec rm -rf '{}' \;
-cp -rf /tmp/Surfn/* ~/.icons/
+git clone https://github.com/erikdubois/$ICON_PACKAGE /tmp/$ICON_PACKAGE
+find /tmp/$ICON_PACKAGE -maxdepth 1 -type f -exec rm -rf '{}' \;
+cp -rf /tmp/$ICON_PACKAGE/* ~/.icons/
 
 # cleaning tmp
-[ -d /tmp/Surfn ] && rm -rf /tmp/Surfn
+[ -d /tmp/$ICON_PACKAGE ] && rm -rf /tmp/$ICON_PACKAGE
 
 
 

--- a/installation/themes/install-gtk-arc-theme-v1.sh
+++ b/installation/themes/install-gtk-arc-theme-v1.sh
@@ -11,18 +11,25 @@
 #
 ##################################################################################################################
 
-#https://github.com/horst3180/arc-theme
+#https://github.com/horst3180/$THEME_PACKAGE
 
-rm -rf /tmp/arc-theme
+THEME_PACKAGE="arc-theme"
+
+if [ -d "/usr/share/themes/Arc" ]; then
+    echo "It seems \"$THEME_PACKAGE\" is installed already. Skipping reinstallation."
+    exit
+fi
+
+rm -rf /tmp/$THEME_PACKAGE
 
 sudo apt-get install build-essential autoconf automake pkg-config libgtk-3-0 libgtk-3-dev -y
 sudo apt-get -f install
-git clone https://github.com/horst3180/arc-theme --depth 1 /tmp/arc-theme
-cd /tmp/arc-theme
+git clone https://github.com/horst3180/$THEME_PACKAGE --depth 1 /tmp/$THEME_PACKAGE
+cd /tmp/$THEME_PACKAGE
 sh autogen.sh --prefix=/usr
 sudo make install
 
-rm -rf /tmp/arc-theme
+rm -rf /tmp/$THEME_PACKAGE
 
 # sudo rm -rf /usr/share/themes/{Arc,Arc-Darker,Arc-Dark}
 

--- a/installation/themes/theme-arc-colora-collection-3.4-v1.sh
+++ b/installation/themes/theme-arc-colora-collection-3.4-v1.sh
@@ -54,15 +54,23 @@
 #
 ##################################################################################################################
 
+THEME_PACKAGE="Arc-Theme-Colora-Collection"
+THEME_FOLDER_TO_CHECK="Arc-Casablanca"
+
+if [ -d $HOME"/.themes/$THEME_FOLDER_TO_CHECK" ]; then
+    echo "It seems \"$THEME_PACKAGE\" is installed already. Skipping reinstallation."
+    exit
+fi
+
 # if there is no hidden folder then make one
 [ -d $HOME"/.themes" ] || mkdir -p $HOME"/.themes"
 
 
-rm -rf /tmp/Arc-Theme-Colora-Collection
-git clone https://github.com/erikdubois/Arc-Theme-Colora-Collection /tmp/Arc-Theme-Colora-Collection
-find /tmp/Arc-Theme-Colora-Collection -maxdepth 1 -type f -exec rm -rf '{}' \;
-cp -r /tmp/Arc-Theme-Colora-Collection/Cinnamon\ 3.4/* ~/.themes/
-rm -rf /tmp/Arc-Theme-Colora-Collection
+rm -rf /tmp/$THEME_PACKAGE
+git clone https://github.com/erikdubois/$THEME_PACKAGE /tmp/$THEME_PACKAGE
+find /tmp/$THEME_PACKAGE -maxdepth 1 -type f -exec rm -rf '{}' \;
+cp -r /tmp/$THEME_PACKAGE/Cinnamon\ 3.4/* ~/.themes/
+rm -rf /tmp/$THEME_PACKAGE
 
 
 echo "################################################################"

--- a/installation/themes/theme-mint-y-colora-collection-3.4-v1.sh
+++ b/installation/themes/theme-mint-y-colora-collection-3.4-v1.sh
@@ -6,14 +6,22 @@
 #
 ##################################################################################################################
 
+THEME_PACKAGE="Mint-Y-Colora-Theme-Collection"
+THEME_FOLDER_TO_CHECK="Mint-Y-Casablanca"
+
+if [ -d $HOME"/.themes/$THEME_FOLDER_TO_CHECK" ]; then
+    echo "It seems \"$THEME_PACKAGE\" is installed already. Skipping reinstallation."
+    exit
+fi
+
 # if there is no hidden folder then make one
 [ -d $HOME"/.themes" ] || mkdir -p $HOME"/.themes"
 
-rm -rf /tmp/Mint-Y-Colora-Theme-Collection
-git clone https://github.com/erikdubois/Mint-Y-Colora-Theme-Collection /tmp/Mint-Y-Colora-Theme-Collection
-find /tmp/Mint-Y-Colora-Theme-Collection -maxdepth 1 -type f -exec rm -rf '{}' \;
-cp -r /tmp/Mint-Y-Colora-Theme-Collection/Cinnamon\ 3.4/* ~/.themes/
-rm -rf /tmp/Mint-Y-Colora-Theme-Collection
+rm -rf /tmp/$THEME_PACKAGE
+git clone https://github.com/erikdubois/$THEME_PACKAGE /tmp/$THEME_PACKAGE
+find /tmp/$THEME_PACKAGE -maxdepth 1 -type f -exec rm -rf '{}' \;
+cp -r /tmp/$THEME_PACKAGE/Cinnamon\ 3.4/* ~/.themes/
+# rm -rf /tmp/$THEME_PACKAGE
 
 
 


### PR DESCRIPTION
**Fixes:**
- bash scripts SHOULD run with 'bash' (not 'sh', it causes failing of some scripts);
- 'install-gtk-arc-theme-v1.sh' failed boot-up of virtual machines (problem with starting X Server because of 'libglx.so');

**Improvements:**
- Prevent some components from being installed again (it saves a lot of time when system has some components are already installed).